### PR TITLE
Added 'country' parameter for iOS

### DIFF
--- a/src/ios/CDVAppUpdate.m
+++ b/src/ios/CDVAppUpdate.m
@@ -17,11 +17,17 @@ static NSString *const TAG = @"CDVAppUpdate";
     NSString* appID = infoDictionary[@"CFBundleIdentifier"];
     NSString* force_api = nil;
     NSString* force_key = nil;
+    NSString* country = @"";
     if ([command.arguments count] > 0) {
         force_api = [command.arguments objectAtIndex:0];
         force_key = [command.arguments objectAtIndex:1];
+        
+        NSString* argCountry = [command.arguments objectAtIndex:2];
+        if ([argCountry length] > 0) {
+            country = [NSString stringWithFormat:@"/%@", argCountry];
+        }
     }
-    NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"http://itunes.apple.com/lookup?bundleId=%@", appID]];
+    NSURL* url = [NSURL URLWithString:[NSString stringWithFormat:@"https://itunes.apple.com%@/lookup?bundleId=%@", country, appID]];
     NSData* data = [NSData dataWithContentsOfURL:url];
     NSDictionary* lookup = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     NSMutableDictionary *resultObj = [[NSMutableDictionary alloc]initWithCapacity:10];

--- a/www/AppUpdate.js
+++ b/www/AppUpdate.js
@@ -25,20 +25,13 @@ var exec = require("cordova/exec");
 var EMPTY_FN = function() {}
 
 var AppUpdate = {
-    /**
-     * The method used to execute and check for an app update using the AppUpdate plugin
-     *
-     * @param success {Function} - the success callback function that will be called when the plugin executes successfully
-     * @param failure {Function} - the error callback function that will be called when the plugin fails to execute
-     * @param force_api_url {String=""} - an api endpoint to call when checking the app update type for a forced update
-     * @param force_api_response_key {String=""} - the key returned from the api containing the app update type value
-     */
-    needsUpdate: function(success, failure, force_api_url, force_api_response_key) {
+    needsUpdate: function(success, failure, force_api=null, force_key=null, country="") {
+        // if (typeof(taskId) !== 'string') {
+        //     throw "AppUpdate.needsUpdate now requires an appId string as the first argument";
+        // }
         success = success || EMPTY_FN;
         failure = failure || EMPTY_FN;
-        force_api_url = force_api_url || "";
-        force_api_response_key = force_api_response_key || "";
-        exec(success, failure, "AppUpdate", "needsUpdate", [force_api_url, force_api_response_key]);
+        exec(success, failure, "AppUpdate", "needsUpdate",[force_api,force_key,country]);
     }
 };
 


### PR DESCRIPTION
Added additional 'country' parameter to allow those who wish to specify the exact region of the app. This is useful when the app is only distributed in certain regions.

This parameter only applies to iOS.