### PR TITLE
com.google.android.play:core:1.10.0 issues

### DIFF
--- a/src/android/CDVAppUpdate.java
+++ b/src/android/CDVAppUpdate.java
@@ -48,7 +48,7 @@ import com.google.android.play.core.appupdate.AppUpdateManager;
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory;
 import com.google.android.play.core.install.model.AppUpdateType;
 import com.google.android.play.core.install.model.UpdateAvailability;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.Task;
 
 import com.android.volley.RequestQueue;
 

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -1,12 +1,14 @@
 android {
 	compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_20
+        targetCompatibility JavaVersion.VERSION_20
     }
 }
 
 dependencies {
     // Load the google play core library
-    implementation 'com.google.android.play:core:1.10.0'
+    //implementation 'com.google.android.play:core:1.10.0'
+    implementation 'com.google.android.play:review:2.0.1'
+    implementation 'com.google.android.play:app-update:2.1.0'
     implementation 'com.android.volley:volley:1.2.1'
 }


### PR DESCRIPTION
When publishing a new version of app, we have an issue from Google like:


```
com.google.android.play:core has added this note for core:1.10.0:

Update your Play Core Maven dependency to an Android 14 compatible version! Your current Play Core library is incompatible with targetSdkVersion 34 (Android 14), which introduces a backwards-incompatible change to broadcast receivers to improve user security. As a reminder, from August 31, Google Play requires all new app releases to target Android 14. Update to the latest Play Core library version dependency to avoid app crashes: https://developer.android.com/guide/playcore#playcore-migration

```